### PR TITLE
Add basic dashboard landing page without styling

### DIFF
--- a/src/main/java/evswap/swp391to4/controller/AuthController.java
+++ b/src/main/java/evswap/swp391to4/controller/AuthController.java
@@ -2,6 +2,7 @@ package evswap.swp391to4.controller;
 
 import evswap.swp391to4.entity.Driver;
 import evswap.swp391to4.service.DriverService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -22,9 +23,11 @@ public class AuthController {
     @PostMapping("/login")
     public String login(@RequestParam String email,
                         @RequestParam String password,
+                        HttpSession session,
                         RedirectAttributes redirect) {
         try {
             Driver driver = driverService.login(email, password);
+            session.setAttribute("loggedInDriver", driver);
             redirect.addFlashAttribute("loginSuccess", "Login thành công! Chào " + driver.getFullName());
             return "redirect:/dashboard"; // Thay bằng trang sau login
         } catch (Exception e) {

--- a/src/main/java/evswap/swp391to4/controller/DashboardController.java
+++ b/src/main/java/evswap/swp391to4/controller/DashboardController.java
@@ -1,0 +1,41 @@
+package evswap.swp391to4.controller;
+
+import evswap.swp391to4.entity.Driver;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class DashboardController {
+
+    @GetMapping({"/", "/dashboard"})
+    public String showDashboard(HttpSession session, Model model) {
+        Driver driver = (Driver) session.getAttribute("loggedInDriver");
+        if (driver != null) {
+            model.addAttribute("driverName", driver.getFullName());
+            model.addAttribute("loggedIn", true);
+        } else {
+            model.addAttribute("loggedIn", false);
+        }
+        return "dashboard";
+    }
+
+    @PostMapping("/dashboard/action")
+    public String handleDashboardAction(@RequestParam("feature") String feature,
+                                        HttpSession session,
+                                        RedirectAttributes redirect) {
+        Driver driver = (Driver) session.getAttribute("loggedInDriver");
+        if (driver == null) {
+            redirect.addFlashAttribute("loginRequired", "Vui lòng đăng nhập để sử dụng chức năng.");
+            return "redirect:/login";
+        }
+
+        redirect.addFlashAttribute("dashboardMessage", "Bạn đã chọn chức năng: " + feature);
+        return "redirect:/dashboard";
+    }
+}
+

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>EV SWAP Dashboard</title>
+</head>
+<body>
+<header>
+    <h1>EV SWAP</h1>
+    <div th:if="${loggedIn}">
+        <p>Xin chào <span th:text="${driverName}">người dùng</span>!</p>
+        <p>Bạn đã sẵn sàng sử dụng các tiện ích đổi pin.</p>
+    </div>
+    <div th:if="${!loggedIn}">
+        <p>Chào mừng bạn đến với hệ thống đổi pin xe máy điện thông minh.</p>
+        <p>
+            <a th:href="@{/login}">Đăng nhập</a>
+            |
+            <a th:href="@{/register}">Đăng ký</a>
+        </p>
+    </div>
+</header>
+
+<section>
+    <h2>Hệ thống đổi pin xe máy điện</h2>
+    <p>Giải pháp đổi pin nhanh chóng, tiện lợi. Chỉ mất vài phút để tiếp tục di chuyển.</p>
+    <p>Các trạm đổi pin đã sẵn sàng phục vụ trên toàn quốc.</p>
+    <p>Đảm bảo an toàn và đáng tin cậy cho mọi chuyến đi.</p>
+</section>
+
+<section>
+    <h2>Tính năng nổi bật</h2>
+    <p th:if="${dashboardMessage}" th:text="${dashboardMessage}"></p>
+    <form th:action="@{/dashboard/action}" method="post">
+        <p>
+            <button type="submit" name="feature" value="Đổi pin nhanh chóng">Đổi pin nhanh chóng</button>
+        </p>
+        <p>
+            <button type="submit" name="feature" value="Mạng lưới trạm rộng khắp">Mạng lưới trạm rộng khắp</button>
+        </p>
+        <p>
+            <button type="submit" name="feature" value="An toàn và đáng tin cậy">An toàn và đáng tin cậy</button>
+        </p>
+        <p>
+            <button type="submit" name="feature" value="Hoạt động 24/7">Hoạt động 24/7</button>
+        </p>
+        <p>
+            <button type="submit" name="feature" value="Thân thiện môi trường">Thân thiện môi trường</button>
+        </p>
+        <p>
+            <button type="submit" name="feature" value="Tiết kiệm chi phí">Tiết kiệm chi phí</button>
+        </p>
+    </form>
+</section>
+
+<section>
+    <h2>Cách thức hoạt động</h2>
+    <ol>
+        <li>Đăng ký tài khoản để bắt đầu trải nghiệm.</li>
+        <li>Tìm trạm đổi pin gần nhất thông qua ứng dụng.</li>
+        <li>Đổi pin và tiếp tục hành trình của bạn.</li>
+    </ol>
+</section>
+
+<section>
+    <h2>Thông tin đăng nhập demo</h2>
+    <p>Admin: admin@evswap.com / Admin123456</p>
+    <p>Staff: Được cấp bởi Admin khi tham gia hệ thống.</p>
+    <p>Driver: Đăng ký nhanh bằng nút "Đăng ký" ở trên.</p>
+</section>
+
+<section>
+    <h2>Khám phá thêm</h2>
+    <p>
+        <button type="submit" form="contactForm" name="feature" value="Liên hệ tư vấn">Liên hệ tư vấn</button>
+        <button type="submit" form="contactForm" name="feature" value="Đặt lịch trải nghiệm">Đặt lịch trải nghiệm</button>
+    </p>
+</section>
+
+<form id="contactForm" th:action="@{/dashboard/action}" method="post"></form>
+
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,27 +2,19 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Login</title>
-    <style>
-        body { font-family: Arial; padding: 20px; }
-        form { max-width: 400px; margin: auto; }
-        input { width: 100%; padding: 8px; margin: 5px 0; }
-        button { width: 100%; padding: 10px; }
-        .message { text-align: center; margin: 10px 0; color: red; }
-        .success { color: green; }
-        a { display:block; text-align:center; margin-top:10px; color:blue; text-decoration:none; }
-    </style>
 </head>
 <body>
-<h2 style="text-align:center;">Login</h2>
+<h1>Login</h1>
 <form th:action="@{/login}" method="post">
-    Email: <input type="email" name="email" required /><br/>
-    Password: <input type="password" name="password" required /><br/>
-    <button type="submit">Login</button>
+    <p>Email: <input type="email" name="email" required /></p>
+    <p>Password: <input type="password" name="password" required /></p>
+    <p><button type="submit">Login</button></p>
 </form>
 
-<div class="message" th:if="${loginError}" th:text="${loginError}"></div>
-<div class="message success" th:if="${loginSuccess}" th:text="${loginSuccess}"></div>
+<p th:if="${loginError}" th:text="${loginError}"></p>
+<p th:if="${loginSuccess}" th:text="${loginSuccess}"></p>
+<p th:if="${loginRequired}" th:text="${loginRequired}"></p>
 
-<a th:href="@{/register}">Don't have an account? Register</a>
+<p><a th:href="@{/register}">Don't have an account? Register</a></p>
 </body>
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -2,29 +2,20 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Register</title>
-    <style>
-        body { font-family: Arial; padding: 20px; }
-        form { max-width: 400px; margin: auto; }
-        input { width: 100%; padding: 8px; margin: 5px 0; }
-        button { width: 100%; padding: 10px; }
-        .message { text-align: center; margin: 10px 0; color: red; }
-        .success { color: green; }
-        a { display:block; text-align:center; margin-top:10px; color:blue; text-decoration:none; }
-    </style>
 </head>
 <body>
-<h2 style="text-align:center;">Register</h2>
+<h1>Register</h1>
 <form th:action="@{/register}" method="post">
-    Email: <input type="email" name="email" required /><br/>
-    Password: <input type="password" name="password" required /><br/>
-    Full Name: <input type="text" name="fullName" required /><br/>
-    Phone: <input type="text" name="phone" /><br/>
-    <button type="submit">Register</button>
+    <p>Email: <input type="email" name="email" required /></p>
+    <p>Password: <input type="password" name="password" required /></p>
+    <p>Full Name: <input type="text" name="fullName" required /></p>
+    <p>Phone: <input type="text" name="phone" /></p>
+    <p><button type="submit">Register</button></p>
 </form>
 
-<div class="message" th:if="${registerError}" th:text="${registerError}"></div>
-<div class="message success" th:if="${registerSuccess}" th:text="${registerSuccess}"></div>
+<p th:if="${registerError}" th:text="${registerError}"></p>
+<p th:if="${registerSuccess}" th:text="${registerSuccess}"></p>
 
-<a th:href="@{/login}">Already have an account? Login</a>
+<p><a th:href="@{/login}">Already have an account? Login</a></p>
 </body>
 </html>

--- a/src/main/resources/templates/vehicle-register.html
+++ b/src/main/resources/templates/vehicle-register.html
@@ -2,185 +2,26 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Đăng ký phương tiện</title>
-    <style>
-        :root {
-            --primary: #1a73e8;
-            --success: #0f9d58;
-            --background: #f7f9fc;
-            --text-primary: #202124;
-            --text-secondary: #5f6368;
-            --border-radius: 12px;
-        }
-
-        body {
-            margin: 0;
-            font-family: 'Segoe UI', Tahoma, sans-serif;
-            background: var(--background);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
-        }
-
-        .card {
-            background: #fff;
-            width: 480px;
-            border-radius: var(--border-radius);
-            box-shadow: 0 24px 48px rgba(23, 43, 77, 0.12);
-            padding: 32px;
-        }
-
-        .profile {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-            margin-bottom: 24px;
-        }
-
-        .avatar {
-            width: 48px;
-            height: 48px;
-            border-radius: 50%;
-            background: #e8f0fe;
-            color: var(--primary);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 600;
-            font-size: 18px;
-        }
-
-        .profile h2 {
-            margin: 0;
-            font-size: 20px;
-            color: var(--text-primary);
-        }
-
-        .profile span {
-            display: block;
-            color: var(--text-secondary);
-            font-size: 14px;
-        }
-
-        .card h3 {
-            margin: 0 0 24px 0;
-            color: var(--text-secondary);
-            font-weight: 500;
-            line-height: 1.4;
-        }
-
-        form {
-            display: flex;
-            flex-direction: column;
-            gap: 16px;
-        }
-
-        label {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 6px;
-            display: block;
-        }
-
-        input {
-            width: 100%;
-            padding: 12px 14px;
-            border: 1px solid #dadce0;
-            border-radius: 8px;
-            font-size: 14px;
-            transition: border-color 0.2s, box-shadow 0.2s;
-        }
-
-        input:focus {
-            outline: none;
-            border-color: var(--primary);
-            box-shadow: 0 0 0 4px rgba(26, 115, 232, 0.12);
-        }
-
-        .info-box {
-            background: #f1f8ff;
-            border-radius: 10px;
-            padding: 14px 16px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            display: flex;
-            gap: 10px;
-            align-items: flex-start;
-        }
-
-        .info-icon {
-            font-size: 18px;
-        }
-
-        .submit-btn {
-            background: var(--success);
-            color: white;
-            border: none;
-            padding: 14px;
-            border-radius: 10px;
-            font-size: 15px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.2s, box-shadow 0.2s;
-        }
-
-        .submit-btn:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 12px 24px rgba(15, 157, 88, 0.18);
-        }
-
-        .message {
-            margin-bottom: 16px;
-            font-size: 14px;
-        }
-
-        .message.success {
-            color: #0f9d58;
-        }
-
-        .message.error {
-            color: #d93025;
-        }
-    </style>
 </head>
 <body>
-<div class="card">
-    <div class="message success" th:if="${verifySuccess}" th:text="${verifySuccess}"></div>
-    <div class="message error" th:if="${vehicleError}" th:text="${vehicleError}"></div>
+<h1>Đăng ký phương tiện</h1>
 
-    <div class="profile">
-        <div class="avatar" th:text="${driverInitial}">D</div>
-        <div>
-            <h2 th:text="'Xin chào ' + ${driverName}">Xin chào Người dùng</h2>
-            <span>Vui lòng đăng ký thông tin xe máy điện của bạn để sử dụng dịch vụ</span>
-        </div>
-    </div>
+<p th:if="${verifySuccess}" th:text="${verifySuccess}"></p>
+<p th:if="${vehicleError}" th:text="${vehicleError}"></p>
 
-    <form th:action="@{/vehicles/register}" th:object="${vehicleForm}" method="post">
-        <input type="hidden" name="driverId" th:value="${driverId}" />
+<p th:text="'Xin chào ' + ${driverName}">Xin chào Người dùng</p>
+<p>Vui lòng cung cấp thông tin xe máy điện của bạn để hoàn tất hồ sơ.</p>
 
-        <div>
-            <label for="model">Model xe</label>
-            <input id="model" type="text" th:field="*{model}" placeholder="VinFast Klara, Yadea..." required />
-        </div>
+<form th:action="@{/vehicles/register}" th:object="${vehicleForm}" method="post">
+    <input type="hidden" name="driverId" th:value="${driverId}" />
 
-        <div>
-            <label for="vin">Số VIN (Số khung)</label>
-            <input id="vin" type="text" th:field="*{vin}" placeholder="VF1XXXXXXXXXXXXXX" required />
-        </div>
+    <p>Model xe: <input id="model" type="text" th:field="*{model}" required /></p>
+    <p>Số VIN: <input id="vin" type="text" th:field="*{vin}" required /></p>
+    <p>Biển số: <input id="plateNumber" type="text" th:field="*{plateNumber}" /></p>
 
-        <div>
-            <label for="plateNumber">Biển số</label>
-            <input id="plateNumber" type="text" th:field="*{plateNumber}" placeholder="29A1-12345" />
-        </div>
+    <p>Thông tin xe sẽ được sử dụng để xác nhận khi đổi pin tại trạm.</p>
 
-        <div class="info-box">
-            <div class="info-icon">💡</div>
-            <div>Thông tin xe của bạn sẽ được sử dụng để xác nhận khi đổi pin tại trạm</div>
-        </div>
-
-        <button class="submit-btn" type="submit">Hoàn tất đăng ký</button>
-    </form>
-</div>
+    <p><button type="submit">Hoàn tất đăng ký</button></p>
+</form>
 </body>
 </html>

--- a/src/main/resources/templates/verify.html
+++ b/src/main/resources/templates/verify.html
@@ -2,64 +2,18 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Verify Email</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f2f2f2;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-        }
-        .container {
-            background-color: white;
-            padding: 30px 40px;
-            border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.2);
-            width: 400px;
-        }
-        h2 { text-align: center; margin-bottom: 20px; }
-        input {
-            width: 100%;
-            padding: 10px;
-            margin: 8px 0;
-            border-radius: 4px;
-            border: 1px solid #ccc;
-        }
-        button {
-            width: 100%;
-            padding: 12px;
-            background-color: #4CAF50;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            font-size: 16px;
-            cursor: pointer;
-        }
-        button:hover { background-color: #45a049; }
-        .message { text-align: center; margin: 10px 0; }
-        .success { color: green; }
-        .error { color: red; }
-        .link { text-align: center; margin-top: 15px; }
-        .link a { color: #2196F3; text-decoration: none; }
-        .link a:hover { text-decoration: underline; }
-    </style>
 </head>
 <body>
-<div class="container">
-    <h2>Verify Email</h2>
-    <form th:action="@{/verify-otp}" method="post">
-        <input type="email" name="email" placeholder="Email" th:value="${email}" required /><br/>
-        <input type="text" name="otp" placeholder="Enter OTP" required /><br/>
-        <button type="submit">Verify</button>
-    </form>
+<h1>Verify Email</h1>
+<form th:action="@{/verify-otp}" method="post">
+    <p>Email: <input type="email" name="email" th:value="${email}" required /></p>
+    <p>OTP: <input type="text" name="otp" required /></p>
+    <p><button type="submit">Verify</button></p>
+</form>
 
-    <div class="message success" th:if="${verifySuccess}" th:text="${verifySuccess}"></div>
-    <div class="message error" th:if="${verifyError}" th:text="${verifyError}"></div>
+<p th:if="${verifySuccess}" th:text="${verifySuccess}"></p>
+<p th:if="${verifyError}" th:text="${verifyError}"></p>
 
-    <div class="link">
-        <a th:href="@{/login}">Back to Login</a>
-    </div>
-</div>
+<p><a th:href="@{/login}">Back to Login</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a simple Thymeleaf dashboard shown at the root path with plain markup
- store the logged-in driver in the session and gate dashboard actions behind authentication
- remove inline CSS from existing auth-related templates to match the no-style requirement

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e62399948c833290c0caba8284d756