### PR TITLE
Add map-based station finder

### DIFF
--- a/src/main/java/evswap/swp391to4/controller/DashboardController.java
+++ b/src/main/java/evswap/swp391to4/controller/DashboardController.java
@@ -34,6 +34,10 @@ public class DashboardController {
             return "redirect:/login";
         }
 
+        if ("Tìm trạm".equalsIgnoreCase(feature)) {
+            return "redirect:/stations";
+        }
+
         redirect.addFlashAttribute("dashboardMessage", "Bạn đã chọn chức năng: " + feature);
         return "redirect:/dashboard";
     }

--- a/src/main/java/evswap/swp391to4/controller/StationController.java
+++ b/src/main/java/evswap/swp391to4/controller/StationController.java
@@ -1,0 +1,38 @@
+package evswap.swp391to4.controller;
+
+import evswap.swp391to4.dto.StationResponse;
+import evswap.swp391to4.entity.Driver;
+import evswap.swp391to4.service.StationService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class StationController {
+
+    private final StationService stationService;
+
+    @GetMapping("/stations")
+    public String showStations(Model model, HttpSession session) {
+        Driver driver = (Driver) session.getAttribute("loggedInDriver");
+        if (driver == null) {
+            model.addAttribute("loginRequired", "Vui lòng đăng nhập để sử dụng chức năng tìm trạm.");
+            return "login";
+        }
+
+        model.addAttribute("driverName", driver.getFullName());
+        return "stations";
+    }
+
+    @GetMapping("/api/stations")
+    @ResponseBody
+    public List<StationResponse> getStations() {
+        return stationService.getAllStations();
+    }
+}

--- a/src/main/java/evswap/swp391to4/service/StationService.java
+++ b/src/main/java/evswap/swp391to4/service/StationService.java
@@ -40,4 +40,18 @@ public class StationService {
                 .status(saved.getStatus())
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public java.util.List<StationResponse> getAllStations() {
+        return stationRepo.findAll().stream()
+                .map(station -> StationResponse.builder()
+                        .stationId(station.getStationId())
+                        .name(station.getName())
+                        .address(station.getAddress())
+                        .latitude(station.getLatitude())
+                        .longitude(station.getLongitude())
+                        .status(station.getStatus())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/resources/templates/stations.html
+++ b/src/main/resources/templates/stations.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Tìm trạm đổi pin</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-VzL6jCsFh3Z0i26wXZQ1d+oqjUib6h3sUFb4oHBa0+0=" crossorigin=""/>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+
+        header, main {
+            padding: 16px;
+        }
+
+        #map {
+            height: 70vh;
+            width: 100%;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+        }
+
+        .station-list {
+            margin-top: 16px;
+        }
+
+        .station-item {
+            padding: 8px 0;
+            border-bottom: 1px solid #f0f0f0;
+        }
+
+        .actions {
+            margin-top: 16px;
+        }
+
+        .actions a {
+            color: #007bff;
+            text-decoration: none;
+        }
+
+        .actions a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Xin chào <span th:text="${driverName}">người dùng</span></h1>
+    <p>Tìm trạm đổi pin gần bạn trên bản đồ bên dưới.</p>
+</header>
+<main>
+    <div id="map" role="img" aria-label="Bản đồ hiển thị các trạm đổi pin"></div>
+    <section class="station-list">
+        <h2>Danh sách trạm</h2>
+        <div id="stationList"></div>
+    </section>
+    <div class="actions">
+        <a th:href="@{/dashboard}">← Quay lại bảng điều khiển</a>
+    </div>
+</main>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-o9N1j7kGStb9JNRtD9JbIByWuwC2w3Qv0v+3GmZh0Gk=" crossorigin=""></script>
+<script>
+    const map = L.map('map').setView([16.047079, 108.206230], 12);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    const listContainer = document.getElementById('stationList');
+
+    fetch('/api/stations')
+        .then(response => response.json())
+        .then(stations => {
+            if (!stations.length) {
+                listContainer.innerHTML = '<p>Hiện chưa có trạm nào trong hệ thống.</p>';
+                return;
+            }
+
+            const bounds = [];
+
+            stations.forEach(station => {
+                if (station.latitude && station.longitude) {
+                    const lat = parseFloat(station.latitude);
+                    const lng = parseFloat(station.longitude);
+                    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+                        const marker = L.marker([lat, lng]).addTo(map);
+                        marker.bindPopup(`<strong>${station.name}</strong><br/>${station.address ?? 'Chưa cập nhật địa chỉ'}`);
+                        bounds.push([lat, lng]);
+                    }
+                }
+
+                const item = document.createElement('div');
+                item.className = 'station-item';
+                item.innerHTML = `<strong>${station.name}</strong><br/>${station.address ?? 'Chưa cập nhật địa chỉ'}`;
+                listContainer.appendChild(item);
+            });
+
+            if (bounds.length) {
+                map.fitBounds(bounds, {padding: [32, 32]});
+            }
+        })
+        .catch(() => {
+            listContainer.innerHTML = '<p>Không thể tải danh sách trạm. Vui lòng thử lại sau.</p>';
+        });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a controller endpoint that serves a station search page and exposes station data as JSON
- expand the station service so clients can retrieve all stations
- build a new Leaflet-powered stations template and redirect from the dashboard to the map experience

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve org.springframework.boot:spring-boot-starter-parent because Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e648f0b19c83329b9491d87487fb5a