### PR TITLE
Add vehicle type selection to EV registration flow

### DIFF
--- a/src/main/java/evswap/swp391to4/controller/VehicleController.java
+++ b/src/main/java/evswap/swp391to4/controller/VehicleController.java
@@ -3,6 +3,7 @@ package evswap.swp391to4.controller;
 import evswap.swp391to4.dto.VehicleRegistrationForm;
 import evswap.swp391to4.entity.Driver;
 import evswap.swp391to4.entity.Vehicle;
+import evswap.swp391to4.entity.VehicleType;
 import evswap.swp391to4.service.DriverService;
 import evswap.swp391to4.service.VehicleService;
 import jakarta.servlet.http.HttpSession;
@@ -35,6 +36,7 @@ public class VehicleController {
                 .vin(request.vin())
                 .plateNumber(request.plateNumber())
                 .model(request.model())
+                .vehicleType(request.vehicleType())
                 .build();
         Vehicle savedVehicle = vehicleService.addVehicleToDriver(driverId, vehicle);
         return ResponseEntity.ok(savedVehicle);
@@ -79,6 +81,7 @@ public class VehicleController {
                     .model(form.getModel())
                     .vin(form.getVin())
                     .plateNumber(form.getPlateNumber())
+                    .vehicleType(form.getVehicleType())
                     .build();
 
             vehicleService.addVehicleToDriver(driverId, vehicle);
@@ -143,6 +146,7 @@ public class VehicleController {
                     .model(form.getModel())
                     .vin(form.getVin())
                     .plateNumber(form.getPlateNumber())
+                    .vehicleType(form.getVehicleType())
                     .build();
 
             vehicleService.addVehicleToDriver(driver.getDriverId(), vehicle);
@@ -168,7 +172,7 @@ public class VehicleController {
         return fullName.trim().substring(0, 1).toUpperCase();
     }
 
-    public record VehicleRequest(String vin, String plateNumber, String model) {
+    public record VehicleRequest(String vin, String plateNumber, String model, VehicleType vehicleType) {
     }
 
     // Lớp nội bộ để hiển thị dữ liệu trên view, giữ nguyên
@@ -179,6 +183,7 @@ public class VehicleController {
         private final String plateNumber;
         private final String vin;
         private final String model;
+        private final String vehicleTypeLabel;
         private final Instant createdAt;
         private final String statusLabel;
         private final String statusBadge;
@@ -194,6 +199,7 @@ public class VehicleController {
         public String plateNumber() { return plateNumber; }
         public String vin() { return vin; }
         public String model() { return model; }
+        public String vehicleTypeLabel() { return vehicleTypeLabel; }
         public Instant createdAt() { return createdAt; }
         public String statusLabel() { return statusLabel; }
         public String statusBadge() { return statusBadge; }
@@ -238,10 +244,13 @@ public class VehicleController {
                             .orElse("Chưa cập nhật"))
                     .vin(vehicle.getVin())
                     .model(Optional.ofNullable(vehicle.getModel()).orElse("Chưa cập nhật"))
+                    .vehicleTypeLabel(resolveVehicleTypeLabel(vehicle.getVehicleType()))
                     .createdAt(vehicle.getCreatedAt())
                     .statusLabel(batteryPercent >= 75 ? "Đang hoạt động" : "Đang kiểm tra")
                     .statusBadge(statusBadge)
-                    .batteryModel(guessBatteryModel(vehicle.getModel()))
+                    .batteryModel(Optional.ofNullable(vehicle.getBatteryProfile())
+                            .filter(profile -> !profile.isBlank())
+                            .orElseGet(() -> guessBatteryModel(vehicle.getModel())))
                     .batteryStatus(batteryPercent >= 75 ? "Đang sử dụng" : "Cần bảo dưỡng")
                     .batteryPercent(batteryPercent)
                     .healthLabel(healthLabel)
@@ -250,6 +259,13 @@ public class VehicleController {
         }
 
         return cards;
+    }
+
+    private String resolveVehicleTypeLabel(VehicleType vehicleType) {
+        if (vehicleType == null) {
+            return "Chưa phân loại";
+        }
+        return vehicleType.getDisplayName();
     }
 
     // Phương thức đoán model pin, giữ nguyên

--- a/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
+++ b/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
@@ -1,5 +1,6 @@
 package evswap.swp391to4.dto;
 
+import evswap.swp391to4.entity.VehicleType;
 import lombok.Data;
 
 @Data
@@ -7,4 +8,5 @@ public class VehicleRegistrationForm {
     private String model;
     private String vin;
     private String plateNumber;
+    private VehicleType vehicleType = VehicleType.TWO_WHEEL;
 }

--- a/src/main/java/evswap/swp391to4/entity/Vehicle.java
+++ b/src/main/java/evswap/swp391to4/entity/Vehicle.java
@@ -27,6 +27,13 @@ public class Vehicle {
 
     private String model;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vehicle_type", nullable = false)
+    private VehicleType vehicleType;
+
+    @Column(name = "battery_profile", nullable = false)
+    private String batteryProfile;
+
     @Column(name = "created_at")
     private Instant createdAt;
 }

--- a/src/main/java/evswap/swp391to4/entity/VehicleType.java
+++ b/src/main/java/evswap/swp391to4/entity/VehicleType.java
@@ -1,0 +1,16 @@
+package evswap.swp391to4.entity;
+
+public enum VehicleType {
+    FOUR_WHEEL("Ô tô 4 bánh"),
+    TWO_WHEEL("Xe máy điện / Scooter");
+
+    private final String displayName;
+
+    VehicleType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/evswap/swp391to4/service/VehicleService.java
+++ b/src/main/java/evswap/swp391to4/service/VehicleService.java
@@ -1,6 +1,7 @@
 package evswap.swp391to4.service;
 
 import evswap.swp391to4.entity.Vehicle;
+import evswap.swp391to4.entity.VehicleType;
 import evswap.swp391to4.repository.DriverRepository;
 import evswap.swp391to4.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,10 @@ public class VehicleService {
             throw new IllegalStateException("Vui lòng xác minh email trước khi thêm phương tiện");
         }
 
+        if (vehicle.getVehicleType() == null) {
+            throw new IllegalArgumentException("Vui lòng chọn loại phương tiện");
+        }
+
         vehicleRepository.findByVin(vehicle.getVin())
                 .ifPresent(existingVehicle -> {
                     if (existingVehicle.getDriver().getDriverId().equals(driverId)) {
@@ -51,6 +56,7 @@ public class VehicleService {
         vehicle.setVehicleId(null);
         vehicle.setDriver(driver);
         vehicle.setCreatedAt(Instant.now());
+        vehicle.setBatteryProfile(resolveBatteryProfile(vehicle.getVehicleType()));
 
         return vehicleRepository.save(vehicle);
     }
@@ -66,5 +72,16 @@ public class VehicleService {
         }
 
         return vehicleRepository.findByDriverDriverIdOrderByCreatedAtDesc(driverId);
+    }
+
+    private String resolveBatteryProfile(VehicleType vehicleType) {
+        if (vehicleType == null) {
+            return "EVS Pack 48V";
+        }
+
+        return switch (vehicleType) {
+            case FOUR_WHEEL -> "EVS Auto Pack 400V";
+            case TWO_WHEEL -> "EVS Core Pack 48V";
+        };
     }
 }

--- a/src/main/resources/static/css/auth.css
+++ b/src/main/resources/static/css/auth.css
@@ -486,6 +486,107 @@ body {
     font-size: 0.95rem;
 }
 
+.section-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted, rgba(148, 163, 184, 0.72));
+}
+
+.vehicle-type-section {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.vehicle-type-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.vehicle-type-card {
+    position: relative;
+    display: flex;
+    gap: 14px;
+    padding: 18px 20px;
+    border-radius: 18px;
+    border: 1px solid var(--border-color);
+    background: rgba(17, 24, 39, 0.72);
+    cursor: pointer;
+    transition: border 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.vehicle-type-card input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.vehicle-type-card .type-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: rgba(99, 102, 241, 0.16);
+    font-size: 1.3rem;
+}
+
+.vehicle-type-card .type-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.vehicle-type-card .type-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.vehicle-type-card .type-caption {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.vehicle-type-card.is-active {
+    border-color: rgba(34, 211, 238, 0.8);
+    box-shadow: 0 16px 34px rgba(34, 211, 238, 0.25);
+    transform: translateY(-2px);
+}
+
+.vehicle-type-card:hover {
+    border-color: rgba(99, 102, 241, 0.6);
+}
+
+.battery-preview {
+    margin-top: 20px;
+    padding: 18px 20px;
+    border-radius: 18px;
+    background: rgba(99, 102, 241, 0.16);
+    border: 1px solid rgba(99, 102, 241, 0.28);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.battery-preview strong {
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.battery-preview p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
 .vehicle-support {
     padding: 20px;
     border-radius: 22px;

--- a/src/main/resources/static/css/vehicle-manage.css
+++ b/src/main/resources/static/css/vehicle-manage.css
@@ -504,6 +504,89 @@ body.vehicle-manage-body {
     box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.25);
 }
 
+.form-type-selector {
+    border: 1px solid var(--border-soft);
+    border-radius: 18px;
+    padding: 18px 20px 12px;
+    display: grid;
+    gap: 16px;
+    background: rgba(17, 24, 39, 0.72);
+}
+
+.form-type-selector legend {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+}
+
+.form-type-options {
+    display: grid;
+    gap: 12px;
+}
+
+.form-type-card {
+    position: relative;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1px solid var(--border-soft);
+    background: rgba(15, 20, 30, 0.68);
+    cursor: pointer;
+    transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.form-type-card input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.form-type-card .type-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: rgba(99, 102, 241, 0.18);
+    font-size: 1.2rem;
+}
+
+.form-type-card .type-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.form-type-card .type-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.form-type-card .type-caption {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.form-type-card.is-active {
+    border-color: rgba(34, 211, 238, 0.8);
+    box-shadow: 0 12px 28px rgba(34, 211, 238, 0.22);
+    transform: translateY(-1px);
+}
+
+.form-type-card:hover {
+    border-color: rgba(99, 102, 241, 0.6);
+}
+
+.type-summary {
+    margin: 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
 .modal-actions {
     display: flex;
     justify-content: flex-end;

--- a/src/main/resources/templates/vehicle-manage.html
+++ b/src/main/resources/templates/vehicle-manage.html
@@ -97,6 +97,10 @@
                 </div>
                 <div class="vehicle-details">
                     <div class="detail-item">
+                        <span class="detail-label">Loại xe</span>
+                        <span class="detail-value" th:text="${card.vehicleTypeLabel()}">Xe máy điện / Scooter</span>
+                    </div>
+                    <div class="detail-item">
                         <span class="detail-label">Model xe</span>
                         <span class="detail-value" th:text="${card.model()}">VinFast Feliz S</span>
                     </div>
@@ -136,6 +140,30 @@
                     <input type="text" th:field="*{plateNumber}" placeholder="59A3-08364">
                 </label>
             </div>
+            <fieldset class="form-type-selector">
+                <legend>Loại phương tiện</legend>
+                <div class="form-type-options">
+                    <label class="form-type-card" th:classappend="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).FOUR_WHEEL ? ' is-active' : ''">
+                        <input type="radio" th:field="*{vehicleType}" value="FOUR_WHEEL">
+                        <div class="type-icon">🚙</div>
+                        <div class="type-copy">
+                            <span class="type-title">Ô tô 4 bánh</span>
+                            <span class="type-caption">Được ghép với pin EVS Auto Pack 400V</span>
+                        </div>
+                    </label>
+                    <label class="form-type-card" th:classappend="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).TWO_WHEEL ? ' is-active' : ''">
+                        <input type="radio" th:field="*{vehicleType}" value="TWO_WHEEL">
+                        <div class="type-icon">🛵</div>
+                        <div class="type-copy">
+                            <span class="type-title">Xe máy điện / Scooter</span>
+                            <span class="type-caption">Gắn pin EVS Core Pack 48V tiêu chuẩn</span>
+                        </div>
+                    </label>
+                </div>
+                <p class="type-summary" th:text="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).FOUR_WHEEL
+                    ? 'Bạn sẽ được chỉ định bộ pin dung lượng cao EVS Auto Pack 400V.'
+                    : 'Chúng tôi gắn bộ pin tiêu chuẩn EVS Core Pack 48V cho xe hai bánh.'"></p>
+            </fieldset>
             <div class="modal-actions">
                 <button class="btn ghost" type="button" onclick="closeVehicleModal()">Huỷ</button>
                 <button class="btn primary" type="submit">Lưu phương tiện</button>

--- a/src/main/resources/templates/vehicle-register.html
+++ b/src/main/resources/templates/vehicle-register.html
@@ -61,7 +61,7 @@
         </div>
 
         <div class="vehicle-info">
-            <h2 id="vehicle-title">Đăng ký xe máy điện</h2>
+            <h2 id="vehicle-title">Đăng ký phương tiện EV</h2>
             <p>Vui lòng điền chính xác thông tin. Chúng tôi sẽ dùng để đối chiếu khi bạn đổi pin tại trạm EV SWAP.</p>
         </div>
 
@@ -88,6 +88,38 @@
 
             <div class="vehicle-tip">
                 <strong>Gợi ý:</strong> Số VIN thường nằm trên phần thân xe hoặc giấy đăng ký xe. Hãy kiểm tra kỹ để tránh sai sót.
+            </div>
+
+            <div class="vehicle-type-section">
+                <span class="section-label">Loại phương tiện</span>
+                <div class="vehicle-type-options">
+                    <label class="vehicle-type-card" th:classappend="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).FOUR_WHEEL ? ' is-active' : ''">
+                        <input type="radio" th:field="*{vehicleType}" value="FOUR_WHEEL">
+                        <div class="type-icon">🚙</div>
+                        <div class="type-content">
+                            <span class="type-title">Ô tô 4 bánh</span>
+                            <span class="type-caption">Dung lượng pin cao, tương thích EVS Auto Pack 400V</span>
+                        </div>
+                    </label>
+                    <label class="vehicle-type-card" th:classappend="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).TWO_WHEEL ? ' is-active' : ''">
+                        <input type="radio" th:field="*{vehicleType}" value="TWO_WHEEL">
+                        <div class="type-icon">🛵</div>
+                        <div class="type-content">
+                            <span class="type-title">Xe máy điện / Scooter</span>
+                            <span class="type-caption">Tiết kiệm, sử dụng pin EVS Core Pack 48V</span>
+                        </div>
+                    </label>
+                </div>
+            </div>
+
+            <div class="battery-preview">
+                <div>
+                    <span class="section-label">Gói pin gợi ý</span>
+                    <strong th:text="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).FOUR_WHEEL ? 'EVS Auto Pack 400V' : 'EVS Core Pack 48V'"></strong>
+                </div>
+                <p th:text="*{vehicleType} == T(evswap.swp391to4.entity.VehicleType).FOUR_WHEEL
+                    ? 'Phù hợp với các dòng ô tô điện, hỗ trợ sạc nhanh DC và phạm vi di chuyển dài.'
+                    : 'Tối ưu cho xe hai bánh, nhẹ và dễ thay thế tại hơn 200 trạm EV SWAP.'"></p>
             </div>
 
             <div class="auth-submit">


### PR DESCRIPTION
## Summary
- add vehicle type support to the vehicle registration form and management modal so drivers can choose between 4-wheel and 2-wheel EVs
- persist the selected vehicle type with a new VehicleType enum and automatically assign the matching battery profile when saving a vehicle
- surface the vehicle type and battery profile on management cards and enhance styling to highlight the selection and recommended pack

## Testing
- sh mvnw -q test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690624dd3cb08332ab716e92274d6b66