### PR TITLE
Add vehicle type selection for registration and battery mapping

### DIFF
--- a/src/main/java/evswap/swp391to4/config/DataSeeder.java
+++ b/src/main/java/evswap/swp391to4/config/DataSeeder.java
@@ -15,6 +15,7 @@ import evswap.swp391to4.entity.Station;
 import evswap.swp391to4.entity.Vehicle;
 import evswap.swp391to4.entity.VehicleBatteryCompatibility;
 import evswap.swp391to4.entity.VehicleBatteryId;
+import evswap.swp391to4.entity.VehicleType;
 import evswap.swp391to4.repository.BatteryRepository;
 import evswap.swp391to4.repository.DriverRepository;
 import evswap.swp391to4.repository.StaffRepository;
@@ -77,7 +78,8 @@ public class DataSeeder implements CommandLineRunner {
                             .driver(driver)
                             .vin("VIN-TEST-0001")
                             .plateNumber("59A1-000.01")
-                            .model("MODEL-A")
+                            .model("EVS Demo Scooter")
+                            .vehicleType(VehicleType.TWO_WHEEL)
                             .createdAt(Instant.now())
                             .build();
                     return vehicleRepository.save(v);
@@ -85,36 +87,36 @@ public class DataSeeder implements CommandLineRunner {
 
         // Batteries at station
         if (batteryRepository.findAll().isEmpty()) {
-            Battery b1 = batteryRepository.save(Battery.builder()
+            Battery scooterFull = batteryRepository.save(Battery.builder()
                     .station(station)
-                    .model("MODEL-A")
+                    .model(VehicleType.TWO_WHEEL.getDefaultBatteryModel())
                     .state("full")
                     .sohPercent(90)
                     .socPercent(100)
                     .build());
 
-            Battery b2 = batteryRepository.save(Battery.builder()
+            Battery scooterCharging = batteryRepository.save(Battery.builder()
                     .station(station)
-                    .model("MODEL-A")
+                    .model(VehicleType.TWO_WHEEL.getDefaultBatteryModel())
                     .state("charging")
                     .sohPercent(95)
                     .socPercent(50)
                     .build());
 
-            Battery b3 = batteryRepository.save(Battery.builder()
+            Battery carFull = batteryRepository.save(Battery.builder()
                     .station(station)
-                    .model("MODEL-B")
+                    .model(VehicleType.FOUR_WHEEL.getDefaultBatteryModel())
                     .state("full")
-                    .sohPercent(70)
+                    .sohPercent(88)
                     .socPercent(100)
                     .build());
 
-            // Compatibility: vehicle compatible with MODEL-A battery b1
+            // Compatibility: vehicle compatible with scooter battery
             compatibilityRepository.saveAll(List.of(
                     VehicleBatteryCompatibility.builder()
-                            .id(new VehicleBatteryId(vehicle.getVehicleId(), b1.getBatteryId()))
+                            .id(new VehicleBatteryId(vehicle.getVehicleId(), scooterFull.getBatteryId()))
                             .vehicle(vehicle)
-                            .battery(b1)
+                            .battery(scooterFull)
                             .build()
             ));
         }
@@ -137,7 +139,9 @@ public class DataSeeder implements CommandLineRunner {
                 "- Driver: " + driverEmail + " / " + driverPass + " (wallet: 200,000 VND)\n" +
                 "- Staff:  " + staffEmail + " / " + staffPass + " (station: " + station.getName() + ")\n" +
                 "- Vehicle: " + vehicle.getModel() + " (" + vehicle.getPlateNumber() + ")\n" +
-                "- Station has eligible battery MODEL-A (full, 100% SOC, SOH>=80)");
+                "- Station has eligible battery " + VehicleType.TWO_WHEEL.getDefaultBatteryModel() +
+                " (full, 100% SOC, SOH>=80)\n" +
+                "- Station also seeded a sample " + VehicleType.FOUR_WHEEL.getDefaultBatteryModel() + " pack");
     }
 }
 

--- a/src/main/java/evswap/swp391to4/config/DataSeeder.java
+++ b/src/main/java/evswap/swp391to4/config/DataSeeder.java
@@ -2,7 +2,6 @@ package evswap.swp391to4.config;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.List;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;
@@ -85,6 +84,11 @@ public class DataSeeder implements CommandLineRunner {
                     return vehicleRepository.save(v);
                 });
 
+        if (vehicle.getVehicleType() == null) {
+            vehicle.setVehicleType(VehicleType.TWO_WHEEL);
+            vehicle = vehicleRepository.save(vehicle);
+        }
+
         // Batteries at station
         if (batteryRepository.findAll().isEmpty()) {
             Battery scooterFull = batteryRepository.save(Battery.builder()
@@ -112,14 +116,21 @@ public class DataSeeder implements CommandLineRunner {
                     .build());
 
             // Compatibility: vehicle compatible with scooter battery
-            compatibilityRepository.saveAll(List.of(
-                    VehicleBatteryCompatibility.builder()
-                            .id(new VehicleBatteryId(vehicle.getVehicleId(), scooterFull.getBatteryId()))
-                            .vehicle(vehicle)
-                            .battery(scooterFull)
-                            .build()
-            ));
+            ensureCompatibility(vehicle, scooterFull);
+
+            Vehicle car = vehicleRepository.findByVin("VIN-CAR-0001").orElseGet(() -> vehicleRepository.save(Vehicle.builder()
+                    .driver(driver)
+                    .vin("VIN-CAR-0001")
+                    .plateNumber("51H-123.45")
+                    .model("EVS Demo Car")
+                    .vehicleType(VehicleType.FOUR_WHEEL)
+                    .createdAt(Instant.now())
+                    .build()));
+
+            ensureCompatibility(car, carFull);
         }
+
+        Vehicle demoCar = vehicleRepository.findByVin("VIN-CAR-0001").orElse(null);
 
         // Staff account for this station
         String staffEmail = "staff1@test.com";
@@ -139,9 +150,30 @@ public class DataSeeder implements CommandLineRunner {
                 "- Driver: " + driverEmail + " / " + driverPass + " (wallet: 200,000 VND)\n" +
                 "- Staff:  " + staffEmail + " / " + staffPass + " (station: " + station.getName() + ")\n" +
                 "- Vehicle: " + vehicle.getModel() + " (" + vehicle.getPlateNumber() + ")\n" +
+                (demoCar != null ? "- Demo car: " + demoCar.getModel() + " (" + demoCar.getPlateNumber() + ")\n" : "") +
                 "- Station has eligible battery " + VehicleType.TWO_WHEEL.getDefaultBatteryModel() +
                 " (full, 100% SOC, SOH>=80)\n" +
                 "- Station also seeded a sample " + VehicleType.FOUR_WHEEL.getDefaultBatteryModel() + " pack");
+    }
+
+    private void ensureCompatibility(Vehicle vehicle, Battery battery) {
+        if (vehicle == null || battery == null) {
+            return;
+        }
+
+        boolean exists = compatibilityRepository
+                .existsByVehicleVehicleIdAndBatteryModel(vehicle.getVehicleId(), battery.getModel());
+        if (exists) {
+            return;
+        }
+
+        VehicleBatteryCompatibility compatibility = VehicleBatteryCompatibility.builder()
+                .id(new VehicleBatteryId(vehicle.getVehicleId(), battery.getBatteryId()))
+                .vehicle(vehicle)
+                .battery(battery)
+                .build();
+
+        compatibilityRepository.save(compatibility);
     }
 }
 

--- a/src/main/java/evswap/swp391to4/controller/VehicleController.java
+++ b/src/main/java/evswap/swp391to4/controller/VehicleController.java
@@ -188,6 +188,7 @@ public class VehicleController {
         private final String vin;
         private final String model;
         private final String vehicleTypeLabel;
+        private final String vehicleTypeIcon;
         private final Instant createdAt;
         private final String statusLabel;
         private final String statusBadge;
@@ -204,6 +205,7 @@ public class VehicleController {
         public String vin() { return vin; }
         public String model() { return model; }
         public String vehicleTypeLabel() { return vehicleTypeLabel; }
+        public String vehicleTypeIcon() { return vehicleTypeIcon; }
         public Instant createdAt() { return createdAt; }
         public String statusLabel() { return statusLabel; }
         public String statusBadge() { return statusBadge; }
@@ -252,6 +254,7 @@ public class VehicleController {
                     .vin(vehicle.getVin())
                     .model(Optional.ofNullable(vehicle.getModel()).orElse("Chưa cập nhật"))
                     .vehicleTypeLabel(vehicleTypeLabel)
+                    .vehicleTypeIcon(resolveVehicleTypeIcon(vehicle))
                     .createdAt(vehicle.getCreatedAt())
                     .statusLabel(batteryPercent >= 75 ? "Đang hoạt động" : "Đang kiểm tra")
                     .statusBadge(statusBadge)
@@ -294,5 +297,13 @@ public class VehicleController {
             return type.getDisplayName();
         }
         return "Chưa phân loại";
+    }
+
+    private String resolveVehicleTypeIcon(Vehicle vehicle) {
+        VehicleType type = vehicle.getVehicleType();
+        if (type != null) {
+            return type.getIcon();
+        }
+        return "🔋";
     }
 }

--- a/src/main/java/evswap/swp391to4/controller/VehicleController.java
+++ b/src/main/java/evswap/swp391to4/controller/VehicleController.java
@@ -3,6 +3,7 @@ package evswap.swp391to4.controller;
 import evswap.swp391to4.dto.VehicleRegistrationForm;
 import evswap.swp391to4.entity.Driver;
 import evswap.swp391to4.entity.Vehicle;
+import evswap.swp391to4.entity.VehicleType;
 import evswap.swp391to4.service.DriverService;
 import evswap.swp391to4.service.VehicleService;
 import jakarta.servlet.http.HttpSession;
@@ -35,6 +36,7 @@ public class VehicleController {
                 .vin(request.vin())
                 .plateNumber(request.plateNumber())
                 .model(request.model())
+                .vehicleType(request.vehicleType() != null ? request.vehicleType() : VehicleType.TWO_WHEEL)
                 .build();
         Vehicle savedVehicle = vehicleService.addVehicleToDriver(driverId, vehicle);
         return ResponseEntity.ok(savedVehicle);
@@ -59,6 +61,8 @@ public class VehicleController {
                 model.addAttribute("vehicleForm", new VehicleRegistrationForm());
             }
 
+            model.addAttribute("vehicleTypes", VehicleType.values());
+
             return "vehicle-register";
         } catch (Exception e) {
             redirect.addFlashAttribute("loginError", e.getMessage());
@@ -79,6 +83,7 @@ public class VehicleController {
                     .model(form.getModel())
                     .vin(form.getVin())
                     .plateNumber(form.getPlateNumber())
+                    .vehicleType(form.getVehicleType() != null ? form.getVehicleType() : VehicleType.TWO_WHEEL)
                     .build();
 
             vehicleService.addVehicleToDriver(driverId, vehicle);
@@ -121,6 +126,8 @@ public class VehicleController {
             model.addAttribute("vehicleForm", new VehicleRegistrationForm());
         }
 
+        model.addAttribute("vehicleTypes", VehicleType.values());
+
         return "vehicle-manage";
     }
 
@@ -143,6 +150,7 @@ public class VehicleController {
                     .model(form.getModel())
                     .vin(form.getVin())
                     .plateNumber(form.getPlateNumber())
+                    .vehicleType(form.getVehicleType() != null ? form.getVehicleType() : VehicleType.TWO_WHEEL)
                     .build();
 
             vehicleService.addVehicleToDriver(driver.getDriverId(), vehicle);
@@ -168,7 +176,7 @@ public class VehicleController {
         return fullName.trim().substring(0, 1).toUpperCase();
     }
 
-    public record VehicleRequest(String vin, String plateNumber, String model) {
+    public record VehicleRequest(String vin, String plateNumber, String model, VehicleType vehicleType) {
     }
 
     // Lớp nội bộ để hiển thị dữ liệu trên view, giữ nguyên
@@ -179,6 +187,7 @@ public class VehicleController {
         private final String plateNumber;
         private final String vin;
         private final String model;
+        private final String vehicleTypeLabel;
         private final Instant createdAt;
         private final String statusLabel;
         private final String statusBadge;
@@ -194,6 +203,7 @@ public class VehicleController {
         public String plateNumber() { return plateNumber; }
         public String vin() { return vin; }
         public String model() { return model; }
+        public String vehicleTypeLabel() { return vehicleTypeLabel; }
         public Instant createdAt() { return createdAt; }
         public String statusLabel() { return statusLabel; }
         public String statusBadge() { return statusBadge; }
@@ -212,6 +222,9 @@ public class VehicleController {
         for (int index = 0; index < vehicles.size(); index++) {
             Vehicle vehicle = vehicles.get(index);
             int batteryPercent = Math.max(68, 98 - (index * 6));
+
+            String batteryModel = resolveBatteryModel(vehicle);
+            String vehicleTypeLabel = resolveVehicleTypeLabel(vehicle);
 
             String healthLabel;
             String healthDescription;
@@ -238,10 +251,11 @@ public class VehicleController {
                             .orElse("Chưa cập nhật"))
                     .vin(vehicle.getVin())
                     .model(Optional.ofNullable(vehicle.getModel()).orElse("Chưa cập nhật"))
+                    .vehicleTypeLabel(vehicleTypeLabel)
                     .createdAt(vehicle.getCreatedAt())
                     .statusLabel(batteryPercent >= 75 ? "Đang hoạt động" : "Đang kiểm tra")
                     .statusBadge(statusBadge)
-                    .batteryModel(guessBatteryModel(vehicle.getModel()))
+                    .batteryModel(batteryModel)
                     .batteryStatus(batteryPercent >= 75 ? "Đang sử dụng" : "Cần bảo dưỡng")
                     .batteryPercent(batteryPercent)
                     .healthLabel(healthLabel)
@@ -253,7 +267,13 @@ public class VehicleController {
     }
 
     // Phương thức đoán model pin, giữ nguyên
-    private String guessBatteryModel(String vehicleModel) {
+    private String resolveBatteryModel(Vehicle vehicle) {
+        VehicleType type = vehicle.getVehicleType();
+        if (type != null) {
+            return type.getDefaultBatteryModel();
+        }
+
+        String vehicleModel = vehicle.getModel();
         if (vehicleModel == null) {
             return "EVS Pack 48V";
         }
@@ -266,5 +286,13 @@ public class VehicleController {
             return "Dat Bike Hypercore";
         }
         return "EVS Pack 48V";
+    }
+
+    private String resolveVehicleTypeLabel(Vehicle vehicle) {
+        VehicleType type = vehicle.getVehicleType();
+        if (type != null) {
+            return type.getDisplayName();
+        }
+        return "Chưa phân loại";
     }
 }

--- a/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
+++ b/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
@@ -1,5 +1,6 @@
 package evswap.swp391to4.dto;
 
+import evswap.swp391to4.entity.VehicleType;
 import lombok.Data;
 
 @Data
@@ -7,4 +8,5 @@ public class VehicleRegistrationForm {
     private String model;
     private String vin;
     private String plateNumber;
+    private VehicleType vehicleType = VehicleType.TWO_WHEEL;
 }

--- a/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
+++ b/src/main/java/evswap/swp391to4/dto/VehicleRegistrationForm.java
@@ -1,6 +1,7 @@
 package evswap.swp391to4.dto;
 
 import evswap.swp391to4.entity.VehicleType;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
@@ -8,5 +9,6 @@ public class VehicleRegistrationForm {
     private String model;
     private String vin;
     private String plateNumber;
+    @NotNull
     private VehicleType vehicleType = VehicleType.TWO_WHEEL;
 }

--- a/src/main/java/evswap/swp391to4/entity/Vehicle.java
+++ b/src/main/java/evswap/swp391to4/entity/Vehicle.java
@@ -28,7 +28,7 @@ public class Vehicle {
     private String model;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "vehicle_type", nullable = false)
+    @Column(name = "vehicle_type")
     private VehicleType vehicleType;
 
     @Column(name = "created_at")

--- a/src/main/java/evswap/swp391to4/entity/Vehicle.java
+++ b/src/main/java/evswap/swp391to4/entity/Vehicle.java
@@ -27,6 +27,10 @@ public class Vehicle {
 
     private String model;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vehicle_type", nullable = false)
+    private VehicleType vehicleType;
+
     @Column(name = "created_at")
     private Instant createdAt;
 }

--- a/src/main/java/evswap/swp391to4/entity/VehicleType.java
+++ b/src/main/java/evswap/swp391to4/entity/VehicleType.java
@@ -1,0 +1,22 @@
+package evswap.swp391to4.entity;
+
+public enum VehicleType {
+    FOUR_WHEEL("Xe 4 bánh", "EVS Car Pack 100kWh"),
+    TWO_WHEEL("Xe 2 bánh (Scooter)", "EVS Scooter Pack 48V");
+
+    private final String displayName;
+    private final String defaultBatteryModel;
+
+    VehicleType(String displayName, String defaultBatteryModel) {
+        this.displayName = displayName;
+        this.defaultBatteryModel = defaultBatteryModel;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDefaultBatteryModel() {
+        return defaultBatteryModel;
+    }
+}

--- a/src/main/java/evswap/swp391to4/entity/VehicleType.java
+++ b/src/main/java/evswap/swp391to4/entity/VehicleType.java
@@ -1,15 +1,17 @@
 package evswap.swp391to4.entity;
 
 public enum VehicleType {
-    FOUR_WHEEL("Xe 4 bánh", "EVS Car Pack 100kWh"),
-    TWO_WHEEL("Xe 2 bánh (Scooter)", "EVS Scooter Pack 48V");
+    FOUR_WHEEL("Xe 4 bánh", "EVS Car Pack 100kWh", "🚙"),
+    TWO_WHEEL("Xe 2 bánh (Scooter)", "EVS Scooter Pack 48V", "🛵");
 
     private final String displayName;
     private final String defaultBatteryModel;
+    private final String icon;
 
-    VehicleType(String displayName, String defaultBatteryModel) {
+    VehicleType(String displayName, String defaultBatteryModel, String icon) {
         this.displayName = displayName;
         this.defaultBatteryModel = defaultBatteryModel;
+        this.icon = icon;
     }
 
     public String getDisplayName() {
@@ -18,5 +20,9 @@ public enum VehicleType {
 
     public String getDefaultBatteryModel() {
         return defaultBatteryModel;
+    }
+
+    public String getIcon() {
+        return icon;
     }
 }

--- a/src/main/java/evswap/swp391to4/repository/BatteryRepository.java
+++ b/src/main/java/evswap/swp391to4/repository/BatteryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BatteryRepository extends JpaRepository<Battery, Integer> {
@@ -46,4 +47,6 @@ public interface BatteryRepository extends JpaRepository<Battery, Integer> {
      */
     List<Battery> findByStationStationIdAndStateAndSocPercentAndSohPercentGreaterThanEqual(
         Integer stationId, String state, Integer socPercent, Integer sohPercent);
+
+    Optional<Battery> findFirstByModelIgnoreCase(String model);
 }

--- a/src/main/java/evswap/swp391to4/service/BatteryService.java
+++ b/src/main/java/evswap/swp391to4/service/BatteryService.java
@@ -6,8 +6,10 @@ import evswap.swp391to4.entity.Battery;
 import evswap.swp391to4.entity.Staff;
 import evswap.swp391to4.entity.Station;
 import evswap.swp391to4.entity.Vehicle;
+import evswap.swp391to4.entity.VehicleType;
 import evswap.swp391to4.repository.BatteryRepository;
 import evswap.swp391to4.repository.VehicleBatteryCompatibilityRepository;
+import evswap.swp391to4.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class BatteryService {
 
     private final BatteryRepository batteryRepo;
     private final VehicleBatteryCompatibilityRepository compatibilityRepo;
+    private final VehicleRepository vehicleRepository;
 
     @Transactional(readOnly = true)
     public List<Battery> searchBatteriesForStation(Station station, String searchType, String searchTerm) {
@@ -130,12 +133,18 @@ public class BatteryService {
         List<Battery> eligibleBatteries = batteryRepo.findByStationStationIdAndStateAndSocPercentAndSohPercentGreaterThanEqual(
             stationId, "full", 100, 80);
 
+        Vehicle vehicle = vehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy phương tiện với ID: " + vehicleId));
+        VehicleType vehicleType = vehicle.getVehicleType();
+        String requiredModel = vehicleType != null ? vehicleType.getDefaultBatteryModel() : null;
+
         // Lọc theo tương thích với xe
         List<AvailableBatteryResponse> result = new ArrayList<>();
         for (Battery battery : eligibleBatteries) {
-            boolean isCompatible = compatibilityRepo.existsByVehicleVehicleIdAndBatteryModel(
+            boolean matchesType = requiredModel != null && battery.getModel().equalsIgnoreCase(requiredModel);
+            boolean isCompatible = matchesType || compatibilityRepo.existsByVehicleVehicleIdAndBatteryModel(
                 vehicleId, battery.getModel());
-            
+
             if (isCompatible) {
                 result.add(AvailableBatteryResponse.builder()
                     .batteryId(battery.getBatteryId())

--- a/src/main/java/evswap/swp391to4/service/VehicleService.java
+++ b/src/main/java/evswap/swp391to4/service/VehicleService.java
@@ -6,8 +6,14 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import evswap.swp391to4.entity.Battery;
 import evswap.swp391to4.entity.Vehicle;
+import evswap.swp391to4.entity.VehicleBatteryCompatibility;
+import evswap.swp391to4.entity.VehicleBatteryId;
+import evswap.swp391to4.entity.VehicleType;
+import evswap.swp391to4.repository.BatteryRepository;
 import evswap.swp391to4.repository.DriverRepository;
+import evswap.swp391to4.repository.VehicleBatteryCompatibilityRepository;
 import evswap.swp391to4.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +23,8 @@ public class VehicleService {
 
     private final VehicleRepository vehicleRepository;
     private final DriverRepository driverRepository;
+    private final BatteryRepository batteryRepository;
+    private final VehicleBatteryCompatibilityRepository compatibilityRepository;
 
     @Transactional
     public Vehicle addVehicleToDriver(Integer driverId, Vehicle vehicle) {
@@ -29,6 +37,10 @@ public class VehicleService {
 
         if (!Boolean.TRUE.equals(driver.getEmailVerified())) {
             throw new IllegalStateException("Vui lòng xác minh email trước khi thêm phương tiện");
+        }
+
+        if (vehicle.getVehicleType() == null) {
+            throw new IllegalArgumentException("Vui lòng chọn loại phương tiện");
         }
 
         vehicleRepository.findByVin(vehicle.getVin())
@@ -53,7 +65,9 @@ public class VehicleService {
         vehicle.setDriver(driver);
         vehicle.setCreatedAt(Instant.now());
 
-        return vehicleRepository.save(vehicle);
+        Vehicle savedVehicle = vehicleRepository.save(vehicle);
+        assignDefaultCompatibility(savedVehicle);
+        return savedVehicle;
     }
 
     @Transactional(readOnly = true)
@@ -67,5 +81,35 @@ public class VehicleService {
         }
 
         return vehicleRepository.findByDriverDriverIdOrderByCreatedAtDesc(driverId);
+    }
+
+    private void assignDefaultCompatibility(Vehicle vehicle) {
+        VehicleType type = vehicle.getVehicleType();
+        if (type == null) {
+            return;
+        }
+
+        String targetModel = type.getDefaultBatteryModel();
+        Battery representativeBattery = batteryRepository
+                .findFirstByModelIgnoreCase(targetModel)
+                .orElse(null);
+
+        if (representativeBattery == null) {
+            return;
+        }
+
+        boolean exists = compatibilityRepository
+                .existsByVehicleVehicleIdAndBatteryModel(vehicle.getVehicleId(), representativeBattery.getModel());
+        if (exists) {
+            return;
+        }
+
+        VehicleBatteryCompatibility compatibility = VehicleBatteryCompatibility.builder()
+                .id(new VehicleBatteryId(vehicle.getVehicleId(), representativeBattery.getBatteryId()))
+                .vehicle(vehicle)
+                .battery(representativeBattery)
+                .build();
+
+        compatibilityRepository.save(compatibility);
     }
 }

--- a/src/main/resources/static/css/auth.css
+++ b/src/main/resources/static/css/auth.css
@@ -473,6 +473,72 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.vehicle-type-field {
+    display: grid;
+    gap: 12px;
+}
+
+.vehicle-type-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.vehicle-type-options {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.vehicle-type-option {
+    position: relative;
+    border-radius: 22px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.vehicle-type-option input {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent-strong);
+}
+
+.vehicle-type-content {
+    display: grid;
+    gap: 6px;
+    padding: 18px;
+    border-radius: 18px;
+    background: var(--surface);
+    border: 1px solid var(--border-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.vehicle-type-option:hover .vehicle-type-content,
+.vehicle-type-option:focus-within .vehicle-type-content {
+    border-color: var(--accent-strong);
+    box-shadow: 0 16px 32px rgba(34, 211, 238, 0.18);
+    background: rgba(34, 211, 238, 0.12);
+}
+
+.vehicle-type-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.vehicle-type-battery {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.vehicle-type-option input:checked + .vehicle-type-content {
+    border-color: var(--accent);
+    box-shadow: 0 18px 38px rgba(99, 102, 241, 0.28);
+    background: rgba(99, 102, 241, 0.18);
+}
+
 .vehicle-form-grid .auth-field:nth-child(3) {
     grid-column: span 2;
 }
@@ -506,6 +572,10 @@ body {
 
 @media (max-width: 992px) {
     .vehicle-form-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .vehicle-type-options {
         grid-template-columns: 1fr;
     }
 

--- a/src/main/resources/static/css/auth.css
+++ b/src/main/resources/static/css/auth.css
@@ -508,12 +508,24 @@ body {
 
 .vehicle-type-content {
     display: grid;
-    gap: 6px;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 12px;
     padding: 18px;
     border-radius: 18px;
     background: var(--surface);
     border: 1px solid var(--border-color);
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.vehicle-type-icon {
+    font-size: 1.75rem;
+    line-height: 1;
+}
+
+.vehicle-type-text {
+    display: grid;
+    gap: 4px;
 }
 
 .vehicle-type-option:hover .vehicle-type-content,

--- a/src/main/resources/static/css/vehicle-manage.css
+++ b/src/main/resources/static/css/vehicle-manage.css
@@ -517,12 +517,24 @@ body.vehicle-manage-body {
 
 .vehicle-type-content {
     display: grid;
-    gap: 6px;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 12px;
     padding: 16px;
     border-radius: 16px;
     background: rgba(15, 20, 30, 0.78);
     border: 1px solid var(--border-soft);
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.vehicle-type-icon {
+    font-size: 1.75rem;
+    line-height: 1;
+}
+
+.vehicle-type-text {
+    display: grid;
+    gap: 4px;
 }
 
 .vehicle-type-option:hover .vehicle-type-content,
@@ -546,6 +558,17 @@ body.vehicle-manage-body {
     border-color: var(--accent-primary);
     box-shadow: 0 18px 38px rgba(99, 102, 241, 0.28);
     background: rgba(99, 102, 241, 0.18);
+}
+
+.vehicle-type-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.vehicle-type-chip-icon {
+    font-size: 1.2rem;
+    line-height: 1;
 }
 
 .form-grid label {

--- a/src/main/resources/static/css/vehicle-manage.css
+++ b/src/main/resources/static/css/vehicle-manage.css
@@ -482,6 +482,72 @@ body.vehicle-manage-body {
     gap: 18px;
 }
 
+.form-field.vehicle-type-field {
+    display: grid;
+    gap: 12px;
+}
+
+.vehicle-type-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.vehicle-type-options {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.vehicle-type-option {
+    position: relative;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.vehicle-type-option input {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent-secondary);
+}
+
+.vehicle-type-content {
+    display: grid;
+    gap: 6px;
+    padding: 16px;
+    border-radius: 16px;
+    background: rgba(15, 20, 30, 0.78);
+    border: 1px solid var(--border-soft);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.vehicle-type-option:hover .vehicle-type-content,
+.vehicle-type-option:focus-within .vehicle-type-content {
+    border-color: var(--accent-secondary);
+    box-shadow: 0 16px 32px rgba(34, 211, 238, 0.18);
+    background: rgba(34, 211, 238, 0.12);
+}
+
+.vehicle-type-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.vehicle-type-battery {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.vehicle-type-option input:checked + .vehicle-type-content {
+    border-color: var(--accent-primary);
+    box-shadow: 0 18px 38px rgba(99, 102, 241, 0.28);
+    background: rgba(99, 102, 241, 0.18);
+}
+
 .form-grid label {
     display: grid;
     gap: 10px;
@@ -523,6 +589,10 @@ body.vehicle-manage-body {
 
     .vehicle-card {
         padding: 20px;
+    }
+
+    .vehicle-type-options {
+        grid-template-columns: 1fr;
     }
 
     .battery-meta {

--- a/src/main/resources/templates/vehicle-manage.html
+++ b/src/main/resources/templates/vehicle-manage.html
@@ -98,7 +98,10 @@
                 <div class="vehicle-details">
                     <div class="detail-item">
                         <span class="detail-label">Loại phương tiện</span>
-                        <span class="detail-value" th:text="${card.vehicleTypeLabel()}">Xe 2 bánh (Scooter)</span>
+                        <span class="detail-value vehicle-type-chip">
+                            <span class="vehicle-type-chip-icon" th:text="${card.vehicleTypeIcon()}">🛵</span>
+                            <span th:text="${card.vehicleTypeLabel()}">Xe 2 bánh (Scooter)</span>
+                        </span>
                     </div>
                     <div class="detail-item">
                         <span class="detail-label">Model xe</span>
@@ -132,8 +135,11 @@
                     <label class="vehicle-type-option" th:each="type : ${vehicleTypes}">
                         <input type="radio" th:field="*{vehicleType}" th:value="${type}" />
                         <div class="vehicle-type-content">
-                            <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
-                            <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                            <span class="vehicle-type-icon" th:text="${type.icon}">🛵</span>
+                            <div class="vehicle-type-text">
+                                <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
+                                <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                            </div>
                         </div>
                     </label>
                 </div>

--- a/src/main/resources/templates/vehicle-manage.html
+++ b/src/main/resources/templates/vehicle-manage.html
@@ -97,6 +97,10 @@
                 </div>
                 <div class="vehicle-details">
                     <div class="detail-item">
+                        <span class="detail-label">Loại phương tiện</span>
+                        <span class="detail-value" th:text="${card.vehicleTypeLabel()}">Xe 2 bánh (Scooter)</span>
+                    </div>
+                    <div class="detail-item">
                         <span class="detail-label">Model xe</span>
                         <span class="detail-value" th:text="${card.model()}">VinFast Feliz S</span>
                     </div>
@@ -122,6 +126,18 @@
         <h2>Thêm phương tiện mới</h2>
         <p>Nhập thông tin chính xác để EV SWAP đồng bộ dữ liệu và đảm bảo pin phù hợp.</p>
         <form th:action="@{/vehicles}" method="post" th:object="${vehicleForm}" class="modal-form">
+            <div class="form-field vehicle-type-field">
+                <span class="vehicle-type-label">Loại phương tiện</span>
+                <div class="vehicle-type-options" role="radiogroup">
+                    <label class="vehicle-type-option" th:each="type : ${vehicleTypes}">
+                        <input type="radio" th:field="*{vehicleType}" th:value="${type}" />
+                        <div class="vehicle-type-content">
+                            <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
+                            <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                        </div>
+                    </label>
+                </div>
+            </div>
             <div class="form-grid">
                 <label>
                     <span>Model xe</span>

--- a/src/main/resources/templates/vehicle-register.html
+++ b/src/main/resources/templates/vehicle-register.html
@@ -77,8 +77,11 @@
                     <label class="vehicle-type-option" th:each="type : ${vehicleTypes}">
                         <input type="radio" th:field="*{vehicleType}" th:value="${type}" />
                         <div class="vehicle-type-content">
-                            <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
-                            <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                            <span class="vehicle-type-icon" th:text="${type.icon}">🛵</span>
+                            <div class="vehicle-type-text">
+                                <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
+                                <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                            </div>
                         </div>
                     </label>
                 </div>

--- a/src/main/resources/templates/vehicle-register.html
+++ b/src/main/resources/templates/vehicle-register.html
@@ -61,7 +61,7 @@
         </div>
 
         <div class="vehicle-info">
-            <h2 id="vehicle-title">Đăng ký xe máy điện</h2>
+            <h2 id="vehicle-title">Đăng ký phương tiện</h2>
             <p>Vui lòng điền chính xác thông tin. Chúng tôi sẽ dùng để đối chiếu khi bạn đổi pin tại trạm EV SWAP.</p>
         </div>
 
@@ -70,6 +70,19 @@
 
         <form class="auth-form vehicle-form" th:action="@{/vehicles/register}" th:object="${vehicleForm}" method="post">
             <input type="hidden" name="driverId" th:value="${driverId}">
+
+            <div class="auth-field vehicle-type-field">
+                <span class="vehicle-type-label">Loại phương tiện</span>
+                <div class="vehicle-type-options" role="radiogroup">
+                    <label class="vehicle-type-option" th:each="type : ${vehicleTypes}">
+                        <input type="radio" th:field="*{vehicleType}" th:value="${type}" />
+                        <div class="vehicle-type-content">
+                            <span class="vehicle-type-name" th:text="${type.displayName}">Xe 2 bánh</span>
+                            <span class="vehicle-type-battery" th:text="'Pin: ' + ${type.defaultBatteryModel}">Pin: EVS Scooter Pack 48V</span>
+                        </div>
+                    </label>
+                </div>
+            </div>
 
             <div class="vehicle-form-grid">
                 <div class="auth-field">


### PR DESCRIPTION
## Summary
- add a VehicleType enum so vehicles capture their type and associated default battery pack
- hook vehicle registration, services, and seed data into the new vehicle type so compatibility and battery searches respect the classification
- update the vehicle registration and management UIs with type selectors and styling to surface the battery mapping to users

## Testing
- mvn -q test *(fails: unable to resolve parent POM because Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_69064afe53f88332a98cbbdad48a0a61