### PR TITLE
Enhance staff swap completion workflow

### DIFF
--- a/src/main/java/evswap/swp391to4/controller/StaffController.java
+++ b/src/main/java/evswap/swp391to4/controller/StaffController.java
@@ -445,6 +445,15 @@ public class StaffController {
 
             model.addAttribute("reservation", reservation);
             model.addAttribute("stationName", staff.getStation().getName());
+            List<Battery> stationBatteries = batteryService.getAllBatteriesForStation(staff.getStation());
+            List<Battery> availableFullBatteries = stationBatteries.stream()
+                    .filter(b -> "full".equalsIgnoreCase(b.getState()))
+                    .toList();
+            List<Battery> chargingBatteries = stationBatteries.stream()
+                    .filter(b -> "charging".equalsIgnoreCase(b.getState()))
+                    .toList();
+            model.addAttribute("availableFullBatteries", availableFullBatteries);
+            model.addAttribute("chargingBatteries", chargingBatteries);
             return "staff/reservation-detail";
 
         } catch (IllegalStateException e) {
@@ -484,13 +493,16 @@ public class StaffController {
     @PostMapping("/reservations/{id}/complete")
     public String completeReservation(@PathVariable Integer id,
                                       @RequestParam(name = "batteryId", required = false) Integer batteryId,
+                                      @RequestParam(name = "batteryInId", required = false) Integer batteryInId,
+                                      @RequestParam(name = "batteryInSoc", required = false) Integer batteryInSoc,
+                                      @RequestParam(name = "batteryInSoh", required = false) Integer batteryInSoh,
                                       HttpSession session,
                                       RedirectAttributes redirect) {
         try {
             checkStaffLogin(session);
 
             // Chỉ đảm bảo reservation thuộc trạm của staff thông qua view page đã kiểm tra; ở đây cứ chạy logic
-            reservationService.completeSwap(id, batteryId);
+            reservationService.completeSwap(id, batteryId, batteryInId, batteryInSoc, batteryInSoh);
 
             redirect.addFlashAttribute("success", "Đã hoàn tất đổi pin!");
         } catch (IllegalStateException e) {

--- a/src/main/java/evswap/swp391to4/entity/SwapTransaction.java
+++ b/src/main/java/evswap/swp391to4/entity/SwapTransaction.java
@@ -32,4 +32,10 @@ public class SwapTransaction {
     private Instant swappedAt;
 
     private String result; // success/failed/aborted
+
+    @Column(name = "battery_in_soc_percent")
+    private Integer batteryInSocPercent;
+
+    @Column(name = "battery_in_soh_percent")
+    private Integer batteryInSohPercent;
 }

--- a/src/main/java/evswap/swp391to4/service/BatteryService.java
+++ b/src/main/java/evswap/swp391to4/service/BatteryService.java
@@ -96,7 +96,7 @@ public class BatteryService {
             throw new IllegalStateException("Tài khoản staff của bạn chưa được gán trạm.");
         }
 
-        List<String> validStates = List.of("charging", "maintenance", "full");
+        List<String> validStates = List.of("charging", "maintenance", "full", "in_use", "rented");
         if (!validStates.contains(dto.getState().toLowerCase())) {
             throw new IllegalArgumentException("Trạng thái ban đầu không hợp lệ.");
         }

--- a/src/main/java/evswap/swp391to4/service/ReservationService.java
+++ b/src/main/java/evswap/swp391to4/service/ReservationService.java
@@ -219,15 +219,19 @@ public class ReservationService {
     public void reassignBattery(Integer reservationId, Integer newBatteryId) {
         Reservation reservation = reservationRepo.findById(reservationId)
                 .orElseThrow(() -> new IllegalStateException("Không tìm thấy đặt lịch"));
-        
+
         Battery newBattery = batteryService.getBatteryById(newBatteryId);
         if (newBattery == null) {
             throw new IllegalStateException("Không tìm thấy pin mới");
         }
-        
+
+        if (!newBattery.getStation().getStationId().equals(reservation.getStation().getStationId())) {
+            throw new IllegalStateException("Pin không thuộc trạm của đặt lịch");
+        }
+
         // Validate battery eligibility
-        if (!"full".equals(newBattery.getState()) || 
-            newBattery.getSocPercent() != 100 || 
+        if (!"full".equals(newBattery.getState()) ||
+            newBattery.getSocPercent() != 100 ||
             newBattery.getSohPercent() < 80) {
             throw new IllegalStateException("Pin mới không đủ điều kiện");
         }
@@ -241,9 +245,14 @@ public class ReservationService {
      * - Trạng thái chuyển sang completed
      * - Nếu chưa có assignedBattery và staff không truyền batteryId, tự chọn pin đủ điều kiện đầu tiên tại trạm phù hợp với xe
      * - Đánh dấu QR đã sử dụng
+     * - Cập nhật trạng thái pin giao/nhận và log giao dịch swap (bao gồm SOC/SOH pin trả)
      */
     @Transactional
-    public void completeSwap(Integer reservationId, Integer assignedBatteryId) {
+    public void completeSwap(Integer reservationId,
+                             Integer assignedBatteryId,
+                             Integer batteryInId,
+                             Integer batteryInSoc,
+                             Integer batteryInSoh) {
         Reservation reservation = reservationRepo.findById(reservationId)
                 .orElseThrow(() -> new IllegalStateException("Không tìm thấy đặt lịch"));
 
@@ -263,9 +272,11 @@ public class ReservationService {
         if (reservation.getAssignedBattery() == null) {
             Station station = reservation.getStation();
             Vehicle vehicle = reservation.getVehicle();
-
+            VehicleType type = VehicleType.UNIVERSAL;
+            if (vehicle != null && vehicle.getVehicleType() != null) {
+                type = vehicle.getVehicleType();
+            }
             List<Battery> stationBatteries = batteryService.getAllBatteriesForStation(station);
-            VehicleType type = vehicle.getVehicleType() == null ? VehicleType.UNIVERSAL : vehicle.getVehicleType();
 
             Battery chosen = stationBatteries.stream()
                     .filter(b -> "full".equalsIgnoreCase(b.getState()))
@@ -281,6 +292,62 @@ public class ReservationService {
             }
 
             reservation.setAssignedBattery(chosen);
+        }
+
+        Battery batteryOut = reservation.getAssignedBattery();
+        if (batteryOut == null) {
+            throw new IllegalStateException("Chưa có pin giao cho khách. Vui lòng gán pin trước.");
+        }
+
+        if (!batteryOut.getStation().getStationId().equals(reservation.getStation().getStationId())) {
+            throw new IllegalStateException("Pin được gán không thuộc trạm của đặt lịch");
+        }
+
+        if (!"full".equalsIgnoreCase(batteryOut.getState()) ||
+            batteryOut.getSocPercent() == null || batteryOut.getSocPercent() < 100 ||
+            batteryOut.getSohPercent() == null || batteryOut.getSohPercent() < 80) {
+            throw new IllegalStateException("Pin giao cho khách không còn đủ điều kiện. Vui lòng chọn pin khác.");
+        }
+
+        if (batteryInSoc != null && (batteryInSoc < 0 || batteryInSoc > 100)) {
+            throw new IllegalArgumentException("SOC pin trả về phải nằm trong khoảng 0 - 100%");
+        }
+
+        if (batteryInSoh != null && (batteryInSoh < 0 || batteryInSoh > 100)) {
+            throw new IllegalArgumentException("SOH pin trả về phải nằm trong khoảng 0 - 100%");
+        }
+
+        if (batteryInId == null) {
+            throw new IllegalStateException("Vui lòng nhập hoặc chọn pin khách trả về");
+        }
+
+        Battery batteryIn = batteryService.getBatteryById(batteryInId);
+        if (batteryIn == null) {
+            throw new IllegalStateException("Không tìm thấy pin khách trả về");
+        }
+
+        if (!batteryIn.getStation().getStationId().equals(reservation.getStation().getStationId())) {
+            throw new IllegalStateException("Pin khách trả không thuộc trạm này");
+        }
+
+        String batteryInState = batteryIn.getState() == null ? "" : batteryIn.getState();
+        if (!("charging".equalsIgnoreCase(batteryInState)
+                || "in_use".equalsIgnoreCase(batteryInState)
+                || "rented".equalsIgnoreCase(batteryInState))) {
+            throw new IllegalStateException("Pin khách trả về phải đang thuộc kho hoặc trạng thái in_use/rented hợp lệ");
+        }
+
+        if (batteryIn.getBatteryId().equals(batteryOut.getBatteryId())) {
+            throw new IllegalStateException("Pin trả về không thể trùng với pin giao cho khách");
+        }
+
+        batteryOut.setState("in_use");
+        batteryIn.setState("charging");
+        if (batteryInSoc != null) {
+            batteryIn.setSocPercent(batteryInSoc);
+        }
+        if (batteryInSoh != null) {
+            batteryIn.setSohPercent(batteryInSoh);
         }
 
         // Cập nhật trạng thái hoàn tất và QR
@@ -306,7 +373,10 @@ public class ReservationService {
             tx.setResult("success");
         }
         // Optional: map batteries if needed
-        tx.setBatteryOut(reservation.getAssignedBattery());
+        tx.setBatteryOut(batteryOut);
+        tx.setBatteryIn(batteryIn);
+        tx.setBatteryInSocPercent(batteryInSoc);
+        tx.setBatteryInSohPercent(batteryInSoh);
         swapTransactionRepository.save(tx);
     }
 

--- a/src/main/resources/templates/staff/reservation-detail.html
+++ b/src/main/resources/templates/staff/reservation-detail.html
@@ -72,6 +72,15 @@
                         <span class="label">Trạng thái:</span>
                         <span class="value" th:text="${reservation.status == 'pending' ? 'Chờ xác nhận' : (reservation.status == 'confirmed' ? 'Đã xác nhận' : (reservation.status == 'checked_in' ? 'Đã check-in' : (reservation.status == 'completed' ? 'Hoàn tất' : reservation.status)))}">Chờ xác nhận</span>
                     </div>
+                    <div class="detail-item">
+                        <span class="label">Pin đang giữ:</span>
+                        <span class="value" th:if="${reservation.assignedBattery != null}">
+                            <span th:text="${'#' + reservation.assignedBattery.batteryId + ' - ' + reservation.assignedBattery.model}"></span>
+                            <span th:if="${reservation.assignedBattery.sohPercent != null}" class="badge">SOH <span th:text="${reservation.assignedBattery.sohPercent}"></span>%</span>
+                            <span th:if="${reservation.assignedBattery.socPercent != null}" class="badge">SOC <span th:text="${reservation.assignedBattery.socPercent}"></span>%</span>
+                        </span>
+                        <span class="value" th:if="${reservation.assignedBattery == null}">Chưa gán</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -88,9 +97,43 @@
                       method="post" th:if="${reservation.status == 'confirmed'}" style="display: inline;">
                     <button type="submit" class="btn success">Check-in thủ công</button>
                 </form>
-                
+
                 <form th:action="@{/staff/reservations/{id}/complete(id=${reservation.reservationId})}"
-                      method="post" th:if="${reservation.status == 'checked_in'}" style="display: inline;">
+                      method="post" th:if="${reservation.status == 'checked_in'}" class="complete-form">
+                    <div class="form-group">
+                        <label for="batteryId">Pin giao cho khách</label>
+                        <select id="batteryId" name="batteryId" class="input">
+                            <option value="" th:selected="${reservation.assignedBattery == null}">-- Sử dụng pin đã gán/tự chọn --</option>
+                            <option th:each="battery : ${availableFullBatteries}"
+                                    th:value="${battery.batteryId}"
+                                    th:selected="${reservation.assignedBattery != null and reservation.assignedBattery.batteryId == battery.batteryId}"
+                                    th:text="${'#' + battery.batteryId + ' - ' + battery.model + ' (SOH ' + (battery.sohPercent != null ? battery.sohPercent : 'N/A') + '%, SOC ' + (battery.socPercent != null ? battery.socPercent : 'N/A') + '%)'}"></option>
+                        </select>
+                        <p class="form-hint">Chọn pin full khác nếu muốn thay đổi, hoặc bỏ trống để dùng pin đã gán/tự động chọn.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="batteryInIdInput">Pin khách trả về</label>
+                        <input id="batteryInIdInput" name="batteryInId" type="number" class="input" list="charging-battery-options"
+                               placeholder="Nhập ID pin đang sạc" min="1" required>
+                        <datalist id="charging-battery-options">
+                            <option th:each="battery : ${chargingBatteries}"
+                                    th:value="${battery.batteryId}"
+                                    th:text="${'#' + battery.batteryId + ' - ' + battery.model + ' (SOC ' + (battery.socPercent != null ? battery.socPercent : 'N/A') + '%, SOH ' + (battery.sohPercent != null ? battery.sohPercent : 'N/A') + '%)'}"></option>
+                        </datalist>
+                        <p class="form-hint">Chọn nhanh từ kho pin đang sạc hoặc nhập thủ công khi quét QR/mã vạch.</p>
+                    </div>
+                    <div class="form-group two-column">
+                        <div>
+                            <label for="batteryInSoc">SOC đo được (%)</label>
+                            <input id="batteryInSoc" name="batteryInSoc" type="number" class="input" min="0" max="100" step="1"
+                                   placeholder="Ví dụ: 35">
+                        </div>
+                        <div>
+                            <label for="batteryInSoh">SOH đo được (%)</label>
+                            <input id="batteryInSoh" name="batteryInSoh" type="number" class="input" min="0" max="100" step="1"
+                                   placeholder="Ví dụ: 82">
+                        </div>
+                    </div>
                     <button type="submit" class="btn warning">Hoàn tất đổi pin</button>
                 </form>
             </div>
@@ -152,6 +195,19 @@
     box-shadow: 0 8px 32px rgba(0,0,0,0.1);
 }
 
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: rgba(59, 130, 246, 0.2);
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    color: #bfdbfe;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    padding: 0.15rem 0.6rem;
+    margin-left: 0.5rem;
+}
+
 .timeline-card { grid-column: 1 / -1; }
 
 .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
@@ -162,6 +218,49 @@
 .status-badge.confirmed { background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(37, 99, 235, 0.1)); color: #60a5fa; border: 1px solid rgba(59,130,246,0.3); }
 .status-badge.checked-in { background: linear-gradient(135deg, rgba(34,197,94,0.2), rgba(21,128,61,0.1)); color: #10b981; border: 1px solid rgba(34,197,94,0.3); }
 .status-badge.completed { background: linear-gradient(135deg, rgba(107,114,128,0.2), rgba(75,85,99,0.1)); color: #9ca3af; border: 1px solid rgba(107,114,128,0.3); }
+
+.complete-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    font-weight: 600;
+    color: #e5e7eb;
+}
+
+.form-group .form-hint {
+    font-size: 0.8rem;
+    color: rgba(229, 231, 235, 0.7);
+}
+
+.input {
+    background: rgba(17, 24, 39, 0.6);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    border-radius: 10px;
+    padding: 0.6rem 0.8rem;
+    color: #f9fafb;
+}
+
+.input:focus {
+    outline: none;
+    border-color: rgba(16, 185, 129, 0.6);
+    box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+}
 
 .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
 .detail-item { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem 0; border-bottom: 1px solid rgba(255,255,255,0.08); }


### PR DESCRIPTION
## Summary
- let staff choose outgoing and returning batteries (with SOC/SOH inputs) when completing a swap on the reservation detail page
- validate swap completion in the service layer, updating battery states and recording both batteries on the transaction log
- extend battery and swap models to support new states and returned-battery telemetry

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Spring Boot parent POM – 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_690677fd3f0c83329c202cd04a5a8782